### PR TITLE
Use soft version locking on faraday gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in klarna.gemspec
 gemspec
 
-gem 'faraday', '2.7.5'
+gem 'faraday', '< 3.0'
 gem 'rake', '< 14.0'
 gem 'rspec', '< 4.0'
 gem 'vcr', '< 7.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,7 +74,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  faraday (= 2.7.5)
+  faraday (< 3.0)
   klarna-checkout!
   pry
   pry-byebug


### PR DESCRIPTION
The latest versions accordong to Rubygems.

rake 13.0.6
rspec 3.12.0
vcr 6.1.0
webmock 3.18.1

They match what we currently have in our Gemfile.lock file.